### PR TITLE
Add a simple script and kickstart template to launch virtual machines with libvirt

### DIFF
--- a/scripts/libvirt-kickstart/centos8/kickstart.cfg
+++ b/scripts/libvirt-kickstart/centos8/kickstart.cfg
@@ -11,10 +11,8 @@ repo --name="AppStream" --baseurl=https://mirror.phx1.us.spryservers.net/centos/
 
 url --url http://ftp.funet.fi/pub/linux/mirrors/centos/8/BaseOS/x86_64/kickstart/
 
-# On CentOS 8, we will not disable NetworkManager, but this is here for
-# reference
-#services --disabled=NetworkManager --enabled=network
-
+# mount /tmp as tmpfs
+services --enabled=tmp.mount
                                                 
 rootpw CHANGEME
 firewall --disabled
@@ -41,7 +39,7 @@ logvol /home            --fstype xfs  --name=home          --vgname=sys_vg --siz
 logvol /var             --fstype xfs  --name=var           --vgname=sys_vg --size=4096
 logvol /var/log/        --fstype xfs  --name=var_log       --vgname=sys_vg --size=2048
 logvol /var/log/audit   --fstype xfs  --name=var_log_audit --vgname=sys_vg --size=2048
-logvol /tmp             --fstype xfs  --name=tmp           --vgname=sys_vg --size=1024
+logvol swap             --fstype swap --name swap          --vgname sys_vg --size=2048
 
 %packages
 @^minimal-environment

--- a/scripts/libvirt-kickstart/centos8/kickstart.cfg
+++ b/scripts/libvirt-kickstart/centos8/kickstart.cfg
@@ -1,0 +1,83 @@
+# Install
+
+install                                                           
+lang en_US
+keyboard us
+skipx                                                                                                    
+text
+
+repo --name="BaseOS" --baseurl=http://ftp.funet.fi/pub/linux/mirrors/centos/8/BaseOS/x86_64/os/
+repo --name="AppStream" --baseurl=http://ftp.funet.fi/pub/linux/mirrors/centos/8/AppStream/x86_64/os/
+
+url --url http://ftp.funet.fi/pub/linux/mirrors/centos/8/BaseOS/x86_64/kickstart/
+
+# On CentOS 8, we will not disable NetworkManager, but this is here for
+# reference
+#services --disabled=NetworkManager --enabled=network
+
+                                                
+rootpw CHANGEME
+firewall --disabled
+
+# Create user for provisioning? 
+# user --name example --groups=wheel --password CHANGEME
+
+selinux --permissive
+timezone --utc UTC
+bootloader --location=mbr --append="net.ifnames=0"
+                       
+zerombr
+clearpart --all
+
+part /boot --fstype xfs --size=1024 --asprimary
+part pv.01 --size=1 --grow --asprimary
+volgroup sys_vg pv.01
+
+logvol /      --fstype xfs  --name=root  --vgname=sys_vg --size=4864
+logvol /home  --fstype xfs  --name=home  --vgname=sys_vg --size=1024
+logvol /var   --fstype xfs  --name=var   --vgname=sys_vg --size=4096
+logvol /opt   --fstype xfs  --name=opt   --vgname=sys_vg --size=1024
+
+%packages
+@^minimal-environment
+@core
+audit
+curl
+microcode_ctl
+nfs-utils
+nmap-ncat
+openssh
+openssh-server
+parted
+rpm
+tcpdump
+tmux
+traceroute
+vim-common
+vim-enhanced
+wget
+
+-iwl*-firmware
+
+%end
+
+%post
+(
+#!/bin/sh
+
+# revert consistent interface naming to traditional eth0, eth1, etc.
+ln -sf /dev/null /etc/udev/rules.d/80-net-name-slot.rules
+
+# Example: set ssh key for provisioning user?
+#mkdir /home/example/.ssh
+#chown example: /home/example/.ssh
+#chmod 700 /home/example/.ssh
+#echo "ssh-ed25519 CHANGEME example@host" > /home/example/.ssh/authorized_keys
+#chmod 600 /home/example/.ssh/authorized_keys
+#chown example: /home/example/.ssh/authorized_keys
+
+# Possibly: add to sudoers?
+)
+%end
+
+reboot --eject

--- a/scripts/libvirt-kickstart/centos8/kickstart.cfg
+++ b/scripts/libvirt-kickstart/centos8/kickstart.cfg
@@ -33,7 +33,7 @@ part /boot --fstype xfs --size=1024 --asprimary
 part pv.01 --size=1 --grow --asprimary
 volgroup sys_vg pv.01
 
-logvol /      --fstype xfs  --name=root  --vgname=sys_vg --size=4864
+logvol /      --fstype xfs  --name=root  --vgname=sys_vg --size=4096
 logvol /home  --fstype xfs  --name=home  --vgname=sys_vg --size=1024
 logvol /var   --fstype xfs  --name=var   --vgname=sys_vg --size=4096
 logvol /opt   --fstype xfs  --name=opt   --vgname=sys_vg --size=1024

--- a/scripts/libvirt-kickstart/centos8/kickstart.cfg
+++ b/scripts/libvirt-kickstart/centos8/kickstart.cfg
@@ -23,23 +23,9 @@ firewall --disabled
 selinux --permissive
 timezone --utc UTC
 bootloader --location=mbr --append="net.ifnames=0"
-                       
-zerombr
-clearpart --all
 
-part /boot --fstype xfs --size=1024 --asprimary
-part pv.01 --size=1 --grow --asprimary
-volgroup sys_vg pv.01
-
-# Initial volume sizes are small, but can be extended later
-# total: 20GB, leaves some space for expansion
-
-logvol /                --fstype xfs                      --name=root          --vgname=sys_vg --size=6144
-logvol /home            --fstype xfs  --fsoptions="nodev" --name=home          --vgname=sys_vg --size=1024
-logvol /var             --fstype xfs                      --name=var           --vgname=sys_vg --size=4096
-logvol /var/log/        --fstype xfs                      --name=var_log       --vgname=sys_vg --size=4096
-logvol /var/log/audit   --fstype xfs                      --name=var_log_audit --vgname=sys_vg --size=2048
-logvol swap             --fstype swap                     --name swap          --vgname sys_vg --size=2048
+# Partition configuration created in preinstall script
+%include /tmp/part-include
 
 %packages
 @^minimal-environment
@@ -81,6 +67,45 @@ ln -sf /dev/null /etc/udev/rules.d/80-net-name-slot.rules
 
 # Possibly: add to sudoers?
 )
+%end
+%pre
+(
+#!/bin/sh
+set -x
+PATH=/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
+
+# UEFI partitioning
+if [ -d /sys/firmware/efi ]; then
+    cat >/tmp/part-include <<EOF
+clearpart --all --initlabel --drives vda
+part /boot --fstype xfs --size 1024 --asprimary --ondisk vda
+part /boot/efi --fstype vfat --size 512 --asprimary --ondisk vda
+EOF
+else # BIOS Partitioning
+    cat >/tmp/part-include <<EOF
+clearpart --all --drives=vda
+zerombr
+part /boot --fstype xfs --size=1024 --asprimary --ondisk=vda
+EOF
+fi
+
+# Common part
+cat >>/tmp/part-include <<EOF
+part pv.01 --size=1 --grow --asprimary --ondisk=vda
+volgroup sys_vg pv.01
+
+# Initial volume sizes are small, but can be extended later
+# total: 20GB, leaves some space for expansion
+
+logvol /                --fstype xfs                      --name=root          --vgname=sys_vg --size=6144
+logvol /home            --fstype xfs  --fsoptions="nodev" --name=home          --vgname=sys_vg --size=1024
+logvol /var             --fstype xfs                      --name=var           --vgname=sys_vg --size=4096
+logvol /var/log/        --fstype xfs                      --name=var_log       --vgname=sys_vg --size=4096
+logvol /var/log/audit   --fstype xfs                      --name=var_log_audit --vgname=sys_vg --size=2048
+logvol swap             --fstype swap                     --name swap          --vgname sys_vg --size=2048
+EOF
+
+) >/tmp/kickstart-pre.log 2>&1
 %end
 
 reboot --eject

--- a/scripts/libvirt-kickstart/centos8/kickstart.cfg
+++ b/scripts/libvirt-kickstart/centos8/kickstart.cfg
@@ -34,7 +34,7 @@ volgroup sys_vg pv.01
 # Initial volume sizes are small, but can be extended later
 # total: 15GB, leaves some space for expansion and/or optional swap
 
-logvol /                --fstype xfs  --name=root          --vgname=sys_vg --size=4096
+logvol /                --fstype xfs  --name=root          --vgname=sys_vg --size=6144
 logvol /home            --fstype xfs  --name=home          --vgname=sys_vg --size=1024
 logvol /var             --fstype xfs  --name=var           --vgname=sys_vg --size=4096
 logvol /var/log/        --fstype xfs  --name=var_log       --vgname=sys_vg --size=2048

--- a/scripts/libvirt-kickstart/centos8/kickstart.cfg
+++ b/scripts/libvirt-kickstart/centos8/kickstart.cfg
@@ -32,14 +32,14 @@ part pv.01 --size=1 --grow --asprimary
 volgroup sys_vg pv.01
 
 # Initial volume sizes are small, but can be extended later
-# total: 18GB, leaves some space for expansion
+# total: 20GB, leaves some space for expansion
 
-logvol /                --fstype xfs  --name=root          --vgname=sys_vg --size=6144
-logvol /home            --fstype xfs  --name=home          --vgname=sys_vg --size=1024
-logvol /var             --fstype xfs  --name=var           --vgname=sys_vg --size=4096
-logvol /var/log/        --fstype xfs  --name=var_log       --vgname=sys_vg --size=2048
-logvol /var/log/audit   --fstype xfs  --name=var_log_audit --vgname=sys_vg --size=2048
-logvol swap             --fstype swap --name swap          --vgname sys_vg --size=2048
+logvol /                --fstype xfs                      --name=root          --vgname=sys_vg --size=6144
+logvol /home            --fstype xfs  --fsoptions="nodev" --name=home          --vgname=sys_vg --size=1024
+logvol /var             --fstype xfs                      --name=var           --vgname=sys_vg --size=4096
+logvol /var/log/        --fstype xfs                      --name=var_log       --vgname=sys_vg --size=4096
+logvol /var/log/audit   --fstype xfs                      --name=var_log_audit --vgname=sys_vg --size=2048
+logvol swap             --fstype swap                     --name swap          --vgname sys_vg --size=2048
 
 %packages
 @^minimal-environment

--- a/scripts/libvirt-kickstart/centos8/kickstart.cfg
+++ b/scripts/libvirt-kickstart/centos8/kickstart.cfg
@@ -6,8 +6,8 @@ keyboard us
 skipx                                                                                                    
 text
 
-repo --name="BaseOS" --baseurl=http://ftp.funet.fi/pub/linux/mirrors/centos/8/BaseOS/x86_64/os/
-repo --name="AppStream" --baseurl=http://ftp.funet.fi/pub/linux/mirrors/centos/8/AppStream/x86_64/os/
+repo --name="BaseOS" --baseurl=https://mirror.phx1.us.spryservers.net/centos/8.3.2011/BaseOS/x86_64/os/
+repo --name="AppStream" --baseurl=https://mirror.phx1.us.spryservers.net/centos/8.3.2011/AppStream/x86_64/os/
 
 url --url http://ftp.funet.fi/pub/linux/mirrors/centos/8/BaseOS/x86_64/kickstart/
 

--- a/scripts/libvirt-kickstart/centos8/kickstart.cfg
+++ b/scripts/libvirt-kickstart/centos8/kickstart.cfg
@@ -32,7 +32,7 @@ part pv.01 --size=1 --grow --asprimary
 volgroup sys_vg pv.01
 
 # Initial volume sizes are small, but can be extended later
-# total: 15GB, leaves some space for expansion and/or optional swap
+# total: 18GB, leaves some space for expansion
 
 logvol /                --fstype xfs  --name=root          --vgname=sys_vg --size=6144
 logvol /home            --fstype xfs  --name=home          --vgname=sys_vg --size=1024

--- a/scripts/libvirt-kickstart/centos8/kickstart.cfg
+++ b/scripts/libvirt-kickstart/centos8/kickstart.cfg
@@ -33,10 +33,15 @@ part /boot --fstype xfs --size=1024 --asprimary
 part pv.01 --size=1 --grow --asprimary
 volgroup sys_vg pv.01
 
-logvol /      --fstype xfs  --name=root  --vgname=sys_vg --size=4096
-logvol /home  --fstype xfs  --name=home  --vgname=sys_vg --size=1024
-logvol /var   --fstype xfs  --name=var   --vgname=sys_vg --size=4096
-logvol /opt   --fstype xfs  --name=opt   --vgname=sys_vg --size=1024
+# Initial volume sizes are small, but can be extended later
+# total: 15GB, leaves some space for expansion and/or optional swap
+
+logvol /                --fstype xfs  --name=root          --vgname=sys_vg --size=4096
+logvol /home            --fstype xfs  --name=home          --vgname=sys_vg --size=1024
+logvol /var             --fstype xfs  --name=var           --vgname=sys_vg --size=4096
+logvol /var/log/        --fstype xfs  --name=var_log       --vgname=sys_vg --size=2048
+logvol /var/log/audit   --fstype xfs  --name=var_log_audit --vgname=sys_vg --size=2048
+logvol /tmp             --fstype xfs  --name=tmp           --vgname=sys_vg --size=1024
 
 %packages
 @^minimal-environment

--- a/scripts/libvirt-kickstart/centos8/params.sh
+++ b/scripts/libvirt-kickstart/centos8/params.sh
@@ -1,0 +1,5 @@
+export MIRROR="http://ftp.funet.fi/pub/linux/mirrors/centos/8/BaseOS/x86_64/kickstart/"
+export KICKSTART_FILE="centos8/kickstart.cfg"
+export OS_VARIANT="rhel8.2"
+export EXTRA_ARGS=""
+export DISK_SIZE="20"

--- a/scripts/libvirt-kickstart/centos8/params.sh
+++ b/scripts/libvirt-kickstart/centos8/params.sh
@@ -1,4 +1,4 @@
-export MIRROR="http://ftp.funet.fi/pub/linux/mirrors/centos/8/BaseOS/x86_64/kickstart/"
+export MIRROR="https://mirror.phx1.us.spryservers.net/centos/8.3.2011/BaseOS/x86_64/kickstart/"
 export KICKSTART_FILE="centos8/kickstart.cfg"
 export OS_VARIANT="rhel8.2"
 export EXTRA_ARGS=""

--- a/scripts/libvirt-kickstart/centos8/params.sh
+++ b/scripts/libvirt-kickstart/centos8/params.sh
@@ -2,4 +2,4 @@ export MIRROR="https://mirror.phx1.us.spryservers.net/centos/8.3.2011/BaseOS/x86
 export KICKSTART_FILE="centos8/kickstart.cfg"
 export OS_VARIANT="rhel8.2"
 export EXTRA_ARGS=""
-export DISK_SIZE="20"
+export DISK_SIZE="30"

--- a/scripts/libvirt-kickstart/kickstart.sh
+++ b/scripts/libvirt-kickstart/kickstart.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/bash
+set -eu
+DNS="10.1.1.1"
+NET_NAME="libvirt-network"
+TYPE="centos8"
+CPUS="1"
+RAM="2048"
+
+usage() {
+	echo "$0 [-t centos8] [-c CPUs] [-m RAM] vmhost vm.fqdn.example.com"
+  echo
+  echo "the script will output a hopefully-working virt-install line that allows kickstarting a CentOS 8 VM"
+  echo "The vm should have a DNS record"
+  exit 1
+}
+
+while getopts "c:t:m:" OPT; do
+	case "$OPT" in
+		c)
+		CPUS="$OPTARG";
+		;;
+		t)
+		TYPE="$OPTARG";
+		;;
+		m)
+		RAM="$((OPTARG*1024))";
+		;;
+    *)
+    usage
+    ;;
+	esac
+	shift
+	shift
+done
+if [ $# -ne 2 ]; then
+  usage
+fi
+VMHOST="$1"
+NAME="$2"
+CONN="qemu+ssh://$VMHOST/system"
+
+# assume the vms are named with the FQDN for now
+FQDN="$NAME"
+
+
+# Get IP from DNS
+ip=$(dig +short -t A "$FQDN")
+if [ -z "$ip" ]; then
+	echo "No DNS record found: $FQDN"
+	exit 1
+else 
+	ROUTER="$(echo "$ip" | cut -d. -f1-3).1"
+	NETMASK="255.255.255.0"
+fi
+
+# Add ,portgroup=$PG if needed
+NETWORK="network=${NET_NAME}"
+
+IP="ip=${ip}::${ROUTER}:${NETMASK}:${FQDN}:eth0:none nameserver=${DNS}";
+
+source "${TYPE}/params.sh"
+
+
+if [ "$CPUS" -ge 4 ]; then
+	echo "Did you mix CPUs and RAM?"
+	usage
+	exit 1
+fi
+
+if grep -q CHANGEME "$KICKSTART_FILE"; then
+  echo "### found some lines saying 'CHANGEME' in the kickstart file $KICKSTART_FILE. Please review them:"
+  echo
+  grep -n CHANGEME "$KICKSTART_FILE"
+  echo
+  echo '### REMEMBER TO CHANGE THE ROOT PASSWORD AFTER THE INSTALLATION!'
+fi
+
+echo
+echo virt-install --connect \""$CONN"\" \
+	--name \""$NAME"\" \
+	--vcpus \""$CPUS"\" \
+	--ram \""$RAM"\" \
+	--os-variant "$OS_VARIANT" \
+	--disk \""path=/var/lib/libvirt/images/${NAME}_root.qcow2,size=$DISK_SIZE,format=qcow2,bus=scsi"\" \
+	--network \""$NETWORK"\" \
+	--location \""$MIRROR"\" \
+	--initrd-inject \""$KICKSTART_FILE"\" \
+	--extra-args \""ks=file:/kickstart.cfg console=tty0 net.ifnames=0 $IP"\" \
+	"$EXTRA_ARGS"

--- a/scripts/libvirt-kickstart/kickstart.sh
+++ b/scripts/libvirt-kickstart/kickstart.sh
@@ -81,7 +81,7 @@ echo virt-install --connect \""$CONN"\" \
 	--vcpus \""$CPUS"\" \
 	--ram \""$RAM"\" \
 	--os-variant "$OS_VARIANT" \
-	--disk \""path=/var/lib/libvirt/images/${NAME}_root.qcow2,size=$DISK_SIZE,format=qcow2,bus=scsi"\" \
+	--disk \""path=/var/lib/libvirt/images/${NAME}_root.qcow2,size=$DISK_SIZE,format=qcow2,bus=virtio"\" \
 	--network \""$NETWORK"\" \
 	--location \""$MIRROR"\" \
 	--initrd-inject \""$KICKSTART_FILE"\" \

--- a/scripts/libvirt-kickstart/kickstart.sh
+++ b/scripts/libvirt-kickstart/kickstart.sh
@@ -5,6 +5,7 @@ NET_NAME="libvirt-network"
 TYPE="centos8"
 CPUS="1"
 RAM="2048"
+LIBVIRT_DATA_DIR="/var/lib/libvirt/images"
 
 usage() {
 	echo "$0 [-t centos8] [-c CPUs] [-m RAM] vmhost vm.fqdn.example.com"
@@ -81,7 +82,7 @@ echo virt-install --connect \""$CONN"\" \
 	--vcpus \""$CPUS"\" \
 	--ram \""$RAM"\" \
 	--os-variant "$OS_VARIANT" \
-	--disk \""path=/var/lib/libvirt/images/${NAME}_root.qcow2,size=$DISK_SIZE,format=qcow2,bus=virtio"\" \
+	--disk \""path=${LIBVIRT_DATA_DIR}/${NAME}_root.qcow2,size=$DISK_SIZE,format=qcow2,bus=virtio"\" \
 	--network \""$NETWORK"\" \
 	--location \""$MIRROR"\" \
 	--initrd-inject \""$KICKSTART_FILE"\" \

--- a/scripts/libvirt-kickstart/kickstart.sh
+++ b/scripts/libvirt-kickstart/kickstart.sh
@@ -76,15 +76,21 @@ if grep -q CHANGEME "$KICKSTART_FILE"; then
   echo '### REMEMBER TO CHANGE THE ROOT PASSWORD AFTER THE INSTALLATION!'
 fi
 
-echo
-echo virt-install --connect \""$CONN"\" \
-	--name \""$NAME"\" \
-	--vcpus \""$CPUS"\" \
-	--ram \""$RAM"\" \
-	--os-variant "$OS_VARIANT" \
-	--disk \""path=${LIBVIRT_DATA_DIR}/${NAME}_root.qcow2,size=$DISK_SIZE,format=qcow2,bus=virtio"\" \
-	--network \""$NETWORK"\" \
-	--location \""$MIRROR"\" \
-	--initrd-inject \""$KICKSTART_FILE"\" \
-	--extra-args \""ks=file:/kickstart.cfg console=tty0 net.ifnames=0 $IP"\" \
-	"$EXTRA_ARGS"
+echo -n "
+virt-install --connect '$CONN' \\
+	--name '$NAME' \\
+	--vcpus '$CPUS' \\
+	--ram '$RAM' \\
+	--os-variant '$OS_VARIANT' \\
+	--disk 'path=${LIBVIRT_DATA_DIR}/${NAME}_root.qcow2,size=$DISK_SIZE,format=qcow2,bus=virtio' \\
+	--network '$NETWORK' \\
+	--location '$MIRROR' \\
+	--initrd-inject '$KICKSTART_FILE' \\
+	--extra-args 'ks=file:/kickstart.cfg console=tty0 net.ifnames=0 $IP'
+"
+if [ -n "$EXTRA_ARGS" ]; then
+  echo "  $EXTRA_ARGS"
+else
+  # Final newline
+  echo
+fi


### PR DESCRIPTION
Libvirt can kickstart virtual machines pretty easily.

The PR includes a kickstart template and a small script to generate a virt-install invocation that may serve to get things started. Most configuration should of course be done with Ansible. but you do need some way of creating the first few VMs.

I tested it quickly and as far as I can tell it still works. You'll need to set the root passwords etc. in the kickstart template though