### PR TITLE
YAML linter CI

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,0 +1,21 @@
+---
+# https://github.com/ibiqlik/action-yamllint
+name: YAMLlint
+
+on:
+  push:
+    paths:
+      - '**.yml'
+      - '**.yaml'
+
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+
+      - name: yamllint
+        uses: ibiqlik/action-yamllint@v3

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,7 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 160
+    level: warning


### PR DESCRIPTION
Implementation of `YAMLlint` CI running as GitHub action to enforce scripting/coding/style standards right from the start.

Related isssue: https://github.com/rocky-linux/infrastructure/issues/8