### PR TITLE
Add Ansible Lint action and fix lint errors

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,0 +1,31 @@
+---
+# https://github.com/ansible/ansible-lint-action
+name: Ansible Lint
+
+on:
+  push:
+    paths:
+      - '**.yml'
+      - '**.yaml'
+
+jobs:
+  ansible-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 7
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+
+      - name: Add installed collections in Ansible configuration
+        run: |
+          echo '[defaults]' > ansible.cfg
+          echo 'collections_paths = ./collections' >> ansible.cfg
+
+      - name: Install requirements
+        run: ansible-galaxy collection install -r ansible/playbooks/requirements.yml -p collections
+
+      - name: Ansible Lint
+        uses: ansible/ansible-lint-action@master
+        with:
+          args: "--exclude .github"

--- a/ansible/playbooks/adhoc-ipagroups.yml
+++ b/ansible/playbooks/adhoc-ipagroups.yml
@@ -20,7 +20,7 @@
         fail_msg: "We are missing group information or ipa admin password"
 
     - name: "Creating Mandatory Groups"
-      ipagroup:
+      freeipa.ansible_freeipa.ipagroup:
         ipaadmin_password: "{{ ipaadmin_password }}"
         name: "{{ ipaGroup }}"
         description: "{{ ipaDescription }}"

--- a/ansible/playbooks/adhoc-ipausers.yml
+++ b/ansible/playbooks/adhoc-ipausers.yml
@@ -23,7 +23,7 @@
         fail_msg: "We are missing user information or ipa admin password"
 
     - name: "Creating User Account"
-      ipauser:
+      freeipa.ansible_freeipa.ipauser:
         ipaadmin_password: "{{ ipaadmin_password }}"
         name: "{{ ipaName }}"
         first: "{{ ipaFirst }}"

--- a/ansible/playbooks/import-rockygroups.yml
+++ b/ansible/playbooks/import-rockygroups.yml
@@ -1,7 +1,7 @@
 ---
 # Creates the first set of groups for the IdM Infrastructure
 - name: "Creating Mandatory Groups"
-  ipagroup:
+  freeipa.ansible_freeipa.ipagroup:
     ipaadmin_password: "{{ ipaadmin_password }}"
     name: "{{ item.group }}"
     description: "{{ item.description }}"

--- a/ansible/playbooks/import-rockysudo.yml
+++ b/ansible/playbooks/import-rockysudo.yml
@@ -2,7 +2,7 @@
 # Currently only one SUDO role should be created, and that is for the
 # rocky linux admins
 - name: "Creating SUDO Role for Rocky Admins"
-  ipasudorule:
+  freeipa.ansible_freeipa.ipasudorule:
     ipaadmin_password: "{{ ipaadmin_password }}"
     name: All_RockyAdmins
     description: Rocky Linux infrastructure and operations sudo access

--- a/ansible/playbooks/import-rockyusers.yml
+++ b/ansible/playbooks/import-rockyusers.yml
@@ -3,7 +3,7 @@
 # should create both regular and admin accounts for separation of
 # privilege.
 - name: "Creating Initial Accounts"
-  ipauser:
+  freeipa.ansible_freeipa.ipauser:
     ipaadmin_password: "{{ ipaadmin_password }}"
     name: "{{ item.name }}"
     first: "{{ item.first }}"

--- a/ansible/playbooks/init-rocky-install-kvm-hosts.yml
+++ b/ansible/playbooks/init-rocky-install-kvm-hosts.yml
@@ -20,8 +20,9 @@
 
   tasks:
     - name: Check for CPU Virtualization
-      shell: "lscpu | grep -i virtualization"
+      shell: "set -o pipefail; lscpu | grep -i virtualization"
       register: result
+      changed_when: false
       failed_when: "result.rc != 0"
 
     # Install KVM packages
@@ -43,8 +44,9 @@
         enabled: true
 
     - name: Verify KVM module is loaded
-      shell: "lsmod | grep -i kvm"
+      shell: "set -o pipefail; lsmod | grep -i kvm"
       register: result
+      changed_when: false
       failed_when: "result.rc != 0"
 
   post_tasks:

--- a/ansible/playbooks/init-rocky-ipa-internal-dns.yml
+++ b/ansible/playbooks/init-rocky-ipa-internal-dns.yml
@@ -16,7 +16,7 @@
         fail_msg: "We are missing ipa admin password"
 
     - name: "Create Reverse Domains"
-      ipadnszone:
+      freeipa.ansible_freeipa.ipadnszone:
         ipaadmin_password: '{{ ipaadmin_password }}'
         name: '{{ item }}'
       with_items: '{{ rdns }}'

--- a/ansible/playbooks/requirements.yml
+++ b/ansible/playbooks/requirements.yml
@@ -1,3 +1,4 @@
 ---
-- src: freeipa.ansible_freeipa
-- src: community.general
+collections:
+  - freeipa.ansible_freeipa
+  - community.general

--- a/ansible/playbooks/role-rocky-ipa-client.yml
+++ b/ansible/playbooks/role-rocky-ipa-client.yml
@@ -19,7 +19,7 @@
           - "not no_ansible.stat.exists"
         msg: "/etc/no-ansible exists - skipping run on this node"
 
-    - name: Check if we can see LDAP srv records
+#    - name: Check if we can see LDAP srv records
 
 
   roles:

--- a/ansible/playbooks/role-rocky-ipa.yml
+++ b/ansible/playbooks/role-rocky-ipa.yml
@@ -57,6 +57,6 @@
         group: root
 
     - name: "Turn on reverse zone syncing"
-      ipadnsconfig:
+      freeipa.ansible_freeipa.ipadnsconfig:
         ipaadmin_password: '{{ ipaadmin_password }}'
         allow_sync_ptr: true


### PR DESCRIPTION
Add Ansible Lint action as discussed in #8.

The ansible-lint action takes quite a while in the building step setting up the environment: the total time for the action is about 4 minutes because there's no pre-built Docker image. An open issue exists in the ansible-lint-action.

Is that acceptable or should it run only on the master branch/PRs and not on every push?

Additional changes done:
- `requirements.yml` changed to use `collections` dict.
- Add namespaces to IPA playbooks.
- Comment out one unfinished task.
- Modify `shell` module tasks to complete Ansible Lint.