### PR TITLE
Updates syntax and deprecated include statements

### DIFF
--- a/ansible/playbooks/init-rocky-install-kvm-hosts.yml
+++ b/ansible/playbooks/init-rocky-install-kvm-hosts.yml
@@ -28,14 +28,13 @@
     # Install KVM packages
     - name: Installing KVM Packages
       package:
-        name: "{{ item }}"
+        name:
+          - qemu-kvm
+          - libvirt
+          - libvirt-python
+          - libguestfs-tools
+          - virt-install
         state: present
-      with_items:
-        - qemu-kvm
-        - libvirt
-        - libvirt-python
-        - libguestfs-tools
-        - virt-install
 
     - name: Enable and Start libvirtd
       systemd:

--- a/ansible/playbooks/init-rocky-ipa-team.yml
+++ b/ansible/playbooks/init-rocky-ipa-team.yml
@@ -19,10 +19,10 @@
         fail_msg: "We are missing users or ipa admin password"
 
     - name: "Start users"
-      include: import-rockyusers.yml
+      import_playbook: import-rockyusers.yml
 
     - name: "Start groups"
-      include: import-rockygroups.yml
+      import_playbook: import-rockygroups.yml
 
     - name: "Start sudo for admins"
-      include: import-rockysudo.yml
+      import_playbook: import-rockysudo.yml

--- a/ansible/playbooks/init-rocky-system-config.yml
+++ b/ansible/playbooks/init-rocky-system-config.yml
@@ -6,7 +6,7 @@
 
   # This is to try to avoid the handler issue in pre/post tasks
   handlers:
-    - include: handlers/main.yml
+    - import_tasks: handlers/main.yml
 
   pre_tasks:
     - name: Check if ansible cannot be run here
@@ -22,16 +22,16 @@
 
   tasks:
     - name: Loading Variables from OS Common
-      include: tasks/variable_loader_common.yml
+      import_tasks: tasks/variable_loader_common.yml
 
     - name: Configure SSH
-      include: tasks/ssh_config.yml
+      import_tasks: tasks/ssh_config.yml
 
     - name: Configure harden settings
-      include: tasks/harden.yml
+      import_tasks: tasks/harden.yml
 
     - name: Configure PAM
-      include: tasks/authentication.yml
+      import_tasks: tasks/authentication.yml
 
   post_tasks:
     - name: Touching run file that ansible has ran here

--- a/ansible/playbooks/role-rocky-ipa-replica.yml
+++ b/ansible/playbooks/role-rocky-ipa-replica.yml
@@ -9,7 +9,7 @@
 
   # This is to try to avoid the handler issue in pre/post tasks
   handlers:
-    - include: handlers/main.yml
+    - import_tasks: handlers/main.yml
 
   pre_tasks:
     - name: Check if ansible cannot be run here

--- a/ansible/playbooks/role-rocky-ipa.yml
+++ b/ansible/playbooks/role-rocky-ipa.yml
@@ -13,7 +13,7 @@
 
   # This is to try to avoid the handler issue in pre/post tasks
   handlers:
-    - include: handlers/main.yml
+    - import_tasks: handlers/main.yml
 
   pre_tasks:
     - name: Check if ansible cannot be run here

--- a/ansible/playbooks/role-rocky-ipsilon.yml
+++ b/ansible/playbooks/role-rocky-ipsilon.yml
@@ -8,7 +8,7 @@
 
   # This is to try to avoid the handler issue in pre/post tasks
   handlers:
-    - include: handlers/main.yml
+    - import_tasks: handlers/main.yml
 
   pre_tasks:
     - name: Check if ansible cannot be run here


### PR DESCRIPTION
Ansible's `include` statement has been deprecated since v2.4. I think it is better to follow the [guidelines](https://docs.ansible.com/ansible/2.4/playbooks_reuse_includes.html) and use `import_*` or `include_*` accordingly from the very beginning so we don't have to change them later. 