### PR TITLE
auditd moved to separate tasks file

### DIFF
--- a/ansible/playbooks/handlers/main.yml
+++ b/ansible/playbooks/handlers/main.yml
@@ -16,8 +16,3 @@
 
 - name: regenerate_auditd_rules
   command: /sbin/augenrules
-
-- name: restart_auditd
-  service:
-    name: auditd
-    state: restarted

--- a/ansible/playbooks/init-rocky-system-config.yml
+++ b/ansible/playbooks/init-rocky-system-config.yml
@@ -33,6 +33,9 @@
     - name: Configure PAM
       include: tasks/authentication.yml
 
+    - name: Configure auditd
+      include: tasks/auditd.yml
+
   post_tasks:
     - name: Touching run file that ansible has ran here
       file:

--- a/ansible/playbooks/tasks/auditd.yml
+++ b/ansible/playbooks/tasks/auditd.yml
@@ -31,6 +31,5 @@
     backup: true
   notify:
     - regenerate_auditd_rules
-    - restart_auditd
   tags:
     - harden

--- a/ansible/playbooks/tasks/auditd.yml
+++ b/ansible/playbooks/tasks/auditd.yml
@@ -1,0 +1,36 @@
+---
+- name: Ensure auditd is installed
+  package:
+    name: audit
+    state: present
+  tags:
+    - harden
+
+- name: Ensure auditd is enabled
+  service:
+    name: auditd
+    enabled: true
+
+- name: Ensure auditd buffer is OK
+  replace:
+    path: /etc/audit/rules.d/audit.rules
+    regexp: '-b \d+'
+    replace: '-b {{ audit_buffer }}'
+  notify:
+    - regenerate_auditd_rules
+  tags:
+    - harden
+
+- name: Ensure collection audit rules are available
+  template:
+    src: "etc/audit/rules.d/collection.rules.j2"
+    dest: "/etc/audit/rules.d/collection.rules"
+    owner: root
+    group: root
+    mode: '0600'
+    backup: true
+  notify:
+    - regenerate_auditd_rules
+    - restart_auditd
+  tags:
+    - harden

--- a/ansible/playbooks/tasks/harden.yml
+++ b/ansible/playbooks/tasks/harden.yml
@@ -151,39 +151,6 @@
   tags:
     - harden
 
-- name: Auditd
-  block:
-    - name: Ensure auditd is installed
-      package:
-        name: audit
-        state: present
-      tags:
-        - harden
-
-    - name: Ensure auditd buffer is OK
-      replace:
-        path: /etc/audit/rules.d/audit.rules
-        regexp: '-b \d+'
-        replace: '-b {{ audit_buffer }}'
-      notify:
-        - regenerate_auditd_rules
-      tags:
-        - harden
-
-    - name: Ensure collection audit rules are available
-      template:
-        src: "etc/audit/rules.d/collection.rules.j2"
-        dest: "/etc/audit/rules.d/collection.rules"
-        owner: root
-        group: root
-        mode: '0600'
-        backup: true
-      notify:
-        - regenerate_auditd_rules
-        - restart_auditd
-      tags:
-        - harden
-
 - name: Disable Services
   service:
     name: "{{ item }}"


### PR DESCRIPTION
- `auditd` moved to separate tasks file
- handler removed, `auditd.service` can't be managed manually
