### PR TITLE
Issue #183/chrony

### DIFF
--- a/ansible/inventories/production/group_vars/chronyclients/main.yml
+++ b/ansible/inventories/production/group_vars/chronyclients/main.yml
@@ -1,0 +1,3 @@
+---
+
+chrony_timeservers = ["chrony001.rockylinux.com", "chrony002.rockylinux.com"]

--- a/ansible/inventories/production/group_vars/chronyservers/main.yml
+++ b/ansible/inventories/production/group_vars/chronyservers/main.yml
@@ -1,0 +1,4 @@
+---
+
+chrony_server = true
+chrony_allow_cidr = "10.0.0.0/16"

--- a/ansible/inventories/production/hosts.ini
+++ b/ansible/inventories/production/hosts.ini
@@ -22,3 +22,9 @@ build-a-box ansible_host=10.100.1.112
 [ipsilon]
 idp001 ansible_host=10.100.x.x
 
+[chronyservers]
+chronyd001 ansiblehost=10.100.3.110
+chronyd002 ansiblehost=10.200.3.111
+
+[chronyclients]
+build-abox asnsiblehost=10.100.x.x

--- a/ansible/playbooks/handlers/main.yml
+++ b/ansible/playbooks/handlers/main.yml
@@ -17,7 +17,7 @@
 - name: regenerate_auditd_rules
   command: /sbin/augenrules
 
-- name: reload_chrony 
+- name: reload_chrony
   systemd:
     name: "{{ chrony_service_name }}"
     state: restarted

--- a/ansible/playbooks/handlers/main.yml
+++ b/ansible/playbooks/handlers/main.yml
@@ -16,3 +16,9 @@
 
 - name: regenerate_auditd_rules
   command: /sbin/augenrules
+
+- name: reload_chrony 
+  systemd:
+    name: "{{ chrony_service_name }}"
+    state: restarted
+  listen: "chrony service restart"

--- a/ansible/playbooks/init-rocky-chrony.yml
+++ b/ansible/playbooks/init-rocky-chrony.yml
@@ -1,0 +1,11 @@
+---
+# Sets Up Chrony Server/Client
+# Created: @derekmpage
+# Kudos: @danielkubat  @Darkbat91
+- name: Rocky Chrony Runbook 
+  hosts: all
+  become: true
+
+  tasks:
+    - name: Configure Chrony
+      import_tasks: tasks/chrony.yml

--- a/ansible/playbooks/init-rocky-chrony.yml
+++ b/ansible/playbooks/init-rocky-chrony.yml
@@ -2,7 +2,7 @@
 # Sets Up Chrony Server/Client
 # Created: @derekmpage
 # Kudos: @danielkubat  @Darkbat91
-- name: Rocky Chrony Runbook 
+- name: Rocky Chrony Runbook
   hosts: all
   become: true
 

--- a/ansible/playbooks/tasks/chrony.yml
+++ b/ansible/playbooks/tasks/chrony.yml
@@ -1,0 +1,26 @@
+---
+- name: Install chrony packages
+  yum:
+    name: "{{ chrony_packages }}"
+    state: present
+
+- name: Fix permissions for chrony home directory
+  file:
+    path: "{{ chrony_homedir }}"
+    mode: 0750
+    state: directory
+
+- name: Deploy configuration
+  template:
+    src: chrony.conf.j2
+    dest: "{{ chrony_config_file }}"
+    owner: "{{ chrony_owner }}"
+    group: "{{ chrony_group }}"
+    mode: "{{ chrony_mode }}"
+  notify: "chrony service restart"
+
+- name: Manage the state of service
+  systemd:
+    name: "{{ chrony_service_name }}"
+    state: "{{ chrony_service_state }}"
+    enabled: "{{ chrony_service_enabled }}"

--- a/ansible/playbooks/templates/etc/chrony.conf.j2
+++ b/ansible/playbooks/templates/etc/chrony.conf.j2
@@ -1,0 +1,37 @@
+# Remote servers for client association.
+{% for s in chrony_timeservers %}
+server {{ s }} iburst {% if loop.first %}prefer{% endif %}
+{% endfor %}
+
+# Ignore stratum in source selection.
+stratumweight 0
+
+# Record the rate at which the system clock gains/losses time.
+driftfile {{ chrony_homedir }}/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1.0 second.
+makestep 1.0 3
+
+# If chrony_server=true allow clients to connect
+{% if chrony_server is sameas true %}
+allow {{ chrony_allow_cidr }}
+bindaddress 0.0.0.0
+{% else %} 
+# Else If Client Deny NTP client access.
+deny all
+{% endif %}
+
+# Allow cmdaccess for localhost only (monitoring sometimes requires this to be opened to mgmt interface)
+bindcmdaddress 127.0.0.1
+bindcmdaddress ::1
+cmdallow
+
+# Send a message to syslog if a clock adjustment is larger than 0.5 seconds.
+logchange 0.5
+
+# Specify directory for log files.
+logdir {{ chrony_logdir }} 
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync

--- a/ansible/playbooks/vars/chrony.yml
+++ b/ansible/playbooks/vars/chrony.yml
@@ -26,9 +26,9 @@ chrony_service_enabled: yes
 
 # default internet timeservers to use
 chrony_timeservers:
-   - 0.pool.ntp.org
-   - 1.pool.ntp.org
-   - 2.pool.ntp.org
+  - 0.pool.ntp.org
+  - 1.pool.ntp.org
+  - 2.pool.ntp.org
 
 # is chrony ntp server - allows client connections
 chrony_server: false

--- a/ansible/playbooks/vars/chrony.yml
+++ b/ansible/playbooks/vars/chrony.yml
@@ -1,0 +1,34 @@
+---
+# default permissions
+chrony_owner: root
+chrony_group: root
+chrony_mode: 0644
+
+# packages to install
+chrony_packages:
+  - chrony
+
+# configuration files
+chrony_config_file: /etc/chrony.conf
+
+# chrony user homedir
+chrony_homedir: /var/lib/chrony
+
+# service definition
+chrony_service_name: chronyd
+
+# log file
+chrony_log_file: /var/log/chrony
+
+# service state
+chrony_service_state: started
+chrony_service_enabled: yes
+
+# default internet timeservers to use
+chrony_timeservers: []
+   - 0.pool.ntp.org 
+   - 1.pool.ntp.org 
+   - 2.pool.ntp.org
+
+# is chrony ntp server - allows client connections
+chrony_server: false

--- a/ansible/playbooks/vars/chrony.yml
+++ b/ansible/playbooks/vars/chrony.yml
@@ -25,9 +25,9 @@ chrony_service_state: started
 chrony_service_enabled: yes
 
 # default internet timeservers to use
-chrony_timeservers: []
-   - 0.pool.ntp.org 
-   - 1.pool.ntp.org 
+chrony_timeservers:
+   - 0.pool.ntp.org
+   - 1.pool.ntp.org
    - 2.pool.ntp.org
 
 # is chrony ntp server - allows client connections


### PR DESCRIPTION
#183 

Adding support to configure NTP using chrony for servers and clients

Architecture:

chrony servers sync from public ntp: eg. pool.ntp.org
All clients sync from local NTP Chrony servers :eq chronyserver001.rockylinux.org

A very basic setup that does not require all of our client to egress to the internet for the same sync data.