### PR TITLE
[init] Initialize Gitlab EE Role

### DIFF
--- a/ansible/playbooks/role-gitlab-ee.yml
+++ b/ansible/playbooks/role-gitlab-ee.yml
@@ -3,8 +3,14 @@
 - name: Install and Provision Gitlab
   hosts: gitlabservers
   become: true
+  vars_file:
+    - vars/gitlab.yml
 
   pre_tasks:
+    - name: Check if ansible cannot be run here
+      stat:
+        path: /etc/no-ansible
+      register: no_ansible
     - name: Verify if we can run ansible
       assert:
         that:
@@ -18,8 +24,6 @@
   roles:
     - role: geerlingguy.gitlab
       state: present
-      vars_files:
-        - vars/gitlab.yml
 
   post_tasks:
     - name: Touching run file that ansible has ran here

--- a/ansible/playbooks/role-gitlab-ee.yml
+++ b/ansible/playbooks/role-gitlab-ee.yml
@@ -15,8 +15,9 @@
         name: python3-policycoreutils.noarch
         state: present
 
-  role:
+  roles:
     - role: geerlingguy.gitlab
+      state: present
       vars_files:
         - vars/gitlab.yml
 

--- a/ansible/playbooks/role-gitlab-ee.yml
+++ b/ansible/playbooks/role-gitlab-ee.yml
@@ -1,0 +1,30 @@
+---
+# Creates a Gitlab Instance
+- name: Install and Provision Gitlab
+  hosts: gitlabservers
+  become: true
+
+  pre_tasks:
+    - name: Verify if we can run ansible
+      assert:
+        that:
+          - "not no_ansible.stat.exists"
+        msg: "/etc/no-ansible exists - skipping un on this node"
+    - name: Install SELinux packages
+      package:
+        name: python3-policycoreutils.noarch
+        state: present
+
+  role:
+    - role: geerlingguy.gitlab
+      vars_files:
+        - vars/gitlab.yml
+
+  post_tasks:
+    - name: Touching run file that ansible has ran here
+      file:
+        path: /var/log/ansible.run
+        state: touch
+        mode: '0644'
+        owner: root
+        group: root

--- a/ansible/playbooks/vars/gitlab.yml
+++ b/ansible/playbooks/vars/gitlab.yml
@@ -1,5 +1,5 @@
 ---
-gitlab_domain: src.rockylinux.org
+gitlab_domain: git.rockylinux.org
 gitlab_external_url: "https://{gitlab_domain}/"
 
 # Location where all the git repositories will be stored.
@@ -15,15 +15,15 @@ gitlab_ssl_certificate_key: "/etc/gitlab/ssl/{{ gitlab_domain }}.key"
 gitlab_create_self_signed_cert: "true"
 gitlab_self_signed_cert_subj: "/C=US/ST=Missouri/L=Saint Louis/O=IT/CN={{ gitlab_domain }}"
 
-# LDAP Configuration for the future
-gitlab_ldap_enabled: "false"
-gitlab_ldap_host: "example.com"
+# LDAP Configuration
+gitlab_ldap_enabled: "true"
+gitlab_ldap_host: "rockylinux.org"
 gitlab_ldap_port: "389"
-gitlab_ldap_uid: "sAMAccountName"
-gitlab_ldap_method: "plain"
-gitlab_ldap_bind_dn: "CN=Username,CN=Users,DC=example,DC=com"
-gitlab_ldap_password: "password"
-gitlab_ldap_base: "DC=example,DC=com"
+gitlab_ldap_uid: "uid"
+gitlab_ldap_method: "start_tls"
+gitlab_ldap_bind_dn: "uid=binder,cn=sysaccounts,cn=etc,dc=rockylinux,dc=org"
+gitlab_ldap_password: "ThisIsNotThePassword!"
+gitlab_ldap_base: "cn=users,cn=accounts,dc=rockylinux,dc=org"
 
 gitlab_time_zone: "UTC"
 
@@ -33,16 +33,16 @@ gitlab_download_validate_certs: true
 # Email and SMTP configuration (For the future)
 # Email configuration.
 gitlab_email_enabled: "false"
-gitlab_email_from: "gitlab@example.com"
+gitlab_email_from: "gitlab@rockylinux.org"
 gitlab_email_display_name: "Gitlab"
-gitlab_email_reply_to: "gitlab@example.com"
+gitlab_email_reply_to: "gitlab@rockylinux.org"
 # SMTP configuration
 gitlab_smtp_enable: "false"
 gitlab_smtp_address: "smtp.server"
 gitlab_smtp_port: "465"
 gitlab_smtp_user_name: "smtp user"
 gitlab_smtp_password: "smtp password"
-gitlab_smtp_domain: "example.com"
+gitlab_smtp_domain: "rockylinux.org"
 gitlab_smtp_authentication: "login"
 gitlab_smtp_enable_starttls_auto: "true"
 gitlab_smtp_tls: "false"

--- a/ansible/playbooks/vars/gitlab.yml
+++ b/ansible/playbooks/vars/gitlab.yml
@@ -1,0 +1,57 @@
+---
+gitlab_domain: src.rockylinux.org
+gitlab_external_url: "https://{gitlab_domain}/"
+
+# Location where all the git repositories will be stored.
+gitlab_git_data_dir: "/var/opt/gitlab/git-data"
+
+gitlab_backup_path: "/var/opt/gitlab/backups"
+gitlab_edition: "gitlab-ee"
+gitlab_redirect_http_to_https: "true"
+gitlab_ssl_certificate: "/etc/gitlab/ssl/{{ gitlab_domain }}.crt"
+gitlab_ssl_certificate_key: "/etc/gitlab/ssl/{{ gitlab_domain }}.key"
+
+# SSL Self-signed Certificate Configuration.
+gitlab_create_self_signed_cert: "true"
+gitlab_self_signed_cert_subj: "/C=US/ST=Missouri/L=Saint Louis/O=IT/CN={{ gitlab_domain }}"
+
+# LDAP Configuration for the future
+gitlab_ldap_enabled: "false"
+gitlab_ldap_host: "example.com"
+gitlab_ldap_port: "389"
+gitlab_ldap_uid: "sAMAccountName"
+gitlab_ldap_method: "plain"
+gitlab_ldap_bind_dn: "CN=Username,CN=Users,DC=example,DC=com"
+gitlab_ldap_password: "password"
+gitlab_ldap_base: "DC=example,DC=com"
+
+gitlab_time_zone: "UTC"
+
+# Validates Certifications when downloading Gitlab Installation repo
+gitlab_download_validate_certs: true
+
+# Email and SMTP configuration (For the future)
+# Email configuration.
+gitlab_email_enabled: "false"
+gitlab_email_from: "gitlab@example.com"
+gitlab_email_display_name: "Gitlab"
+gitlab_email_reply_to: "gitlab@example.com"
+# SMTP configuration
+gitlab_smtp_enable: "false"
+gitlab_smtp_address: "smtp.server"
+gitlab_smtp_port: "465"
+gitlab_smtp_user_name: "smtp user"
+gitlab_smtp_password: "smtp password"
+gitlab_smtp_domain: "example.com"
+gitlab_smtp_authentication: "login"
+gitlab_smtp_enable_starttls_auto: "true"
+gitlab_smtp_tls: "false"
+gitlab_smtp_openssl_verify_mode: "none"
+gitlab_smtp_ca_path: "/etc/ssl/certs"
+gitlab_smtp_ca_file: "/etc/ssl/certs/ca-certificates.crt"
+
+# In case of reverse proxy
+gitlab_nginx_listen_port: 8080
+gitlab_nginx_listen_https: "false"
+
+gitlab_default_theme: 2


### PR DESCRIPTION
Fixes half (Configuring Gitlab EE) of #184. 

Initialized Playbook to provision Gitlab EE on a Server.

Tested it locally on CentOS 7.