### PR TITLE
IPA Privileges

### DIFF
--- a/ansible/playbooks/adhoc-ipagetkeytab.yml
+++ b/ansible/playbooks/adhoc-ipagetkeytab.yml
@@ -1,0 +1,33 @@
+---
+# This playbook is meant to be used with callable variables, like adhoc or AWX.
+# What: Pulls keytabs for a kerberos service
+# What is expected:
+#  -> ipaService, using this format: SVC/hostname.rockylinux.org@ROCKYLINUX.ORG
+#  -> ipaKeytabFullPath: The full path to the keytab. Example: /etc/gitlab/gitlab.keytab
+#  -> ipaServer: This needs to be one of the IPA servers
+
+- name: Pull keytab from IPA
+  hosts: "{{ host }}"
+  become: false
+  gather_facts: false
+  vars_files:
+    - vars/encpass.yml
+
+  tasks:
+    - name: "Checking for user variables"
+      assert:
+        that:
+          - ipaadmin_password | mandatory
+          - ipaService | mandatory
+          - ipaKeytabFullPath | mandatory
+          - ipaServer | mandatory
+        success_msg: "Required variables provided"
+        fail_msg: "We are missing required information"
+
+    - name: "Pulling keytab"
+      command: "ipa-getkeytab -s {{ ipaServer }} -p {{ ipaService }} -k {{ ipaKeytabFullPath }}"
+      register: ipakeytab_result
+      changed_when:
+        - ipakeytab_result.rc == 0
+      tags:
+        - keytab

--- a/ansible/playbooks/adhoc-ipagroups.yml
+++ b/ansible/playbooks/adhoc-ipagroups.yml
@@ -5,6 +5,7 @@
 - name: Create our initial users
   hosts: ipaserver
   become: false
+  gather_facts: false
   vars_files:
   - vars/encpass.yml
 

--- a/ansible/playbooks/adhoc-ipaservice.yml
+++ b/ansible/playbooks/adhoc-ipaservice.yml
@@ -1,0 +1,26 @@
+---
+# This playbook is meant to be used with callable variables, like adhoc or AWX.
+# What: Creates kerberos services in the idm infrastructure based on the variables provided
+
+- name: Create Services
+  hosts: ipaserver
+  become: false
+  gather_facts: false
+  vars_files:
+    - vars/encpass.yml
+
+  tasks:
+    - name: "Checking for user variables"
+      assert:
+        that:
+          - ipaadmin_password | mandatory
+          - ipaService | mandatory
+        success_msg: "Required variables provided"
+        fail_msg: "We are missing required information"
+
+    - name: "Creating Kerberos Service"
+      freeipa.ansible_freeipa.ipaservice:
+        ipaadmin_password: "{{ ipaadmin_password }}"
+        name: "{{ ipaService }}"
+      tags:
+        - services

--- a/ansible/playbooks/adhoc-ipausers.yml
+++ b/ansible/playbooks/adhoc-ipausers.yml
@@ -5,6 +5,7 @@
 - name: Create a User
   hosts: ipaserver
   become: false
+  gather_facts: false
   vars_files:
   - vars/encpass.yml
 

--- a/ansible/playbooks/import-rockyipaprivs.yml
+++ b/ansible/playbooks/import-rockyipaprivs.yml
@@ -1,0 +1,44 @@
+---
+# Creates necessary privileges for services
+- name: "Creating necessary privileges"
+  freeipa.ansible_freeipa.ipaprivilege:
+    ipaadmin_password: "{{ ipaadmin_password }}"
+    name: "{{ item.privilege }}"
+    description: "{{ item.description }}"
+  loop: "{{ ipaprivileges }}"
+  when: ipaprivileges is defined
+  tags:
+    - rbac
+
+- name: "Creating permissions"
+  freeipa.ansible_freeipa.ipaprivilege:
+    ipaadmin_password: "{{ ipaadmin_password }}"
+    name: "{{ item.privilege }}"
+    permission: "{{ item.permissions }}"
+    action: member
+  loop: "{{ ipaprivileges }}"
+  when: ipaprivileges is defined
+  tags:
+    - rbac
+
+- name: "Creating roles based on custom privileges"
+  freeipa.ansible_freeipa.iparole:
+    ipaadmin_password: "{{ ipaadmin_password }}"
+    name: "{{ item.role }}"
+    privilege: "{{ item.privilege }}"
+    user: "{{ item.user }}"
+  loop: "{{ ipaprivileges }}"
+  when: ipaprivileges is defined
+  tags:
+    - rbac
+
+- name: "Creating roles based on standard privileges"
+  freeipa.ansible_freeipa.iparole:
+    ipaadmin_password: "{{ ipaadmin_password }}"
+    name: "{{ item.role }}"
+    privilege: "{{ item.privileges }}"
+    user: "{{ item.user }}"
+  loop: "{{ iparoles }}"
+  when: iparoles is defined
+  tags:
+    - rbac

--- a/ansible/playbooks/import-rockyusers.yml
+++ b/ansible/playbooks/import-rockyusers.yml
@@ -31,3 +31,18 @@
   loop: "{{ adminusers }}"
   tags:
     - users
+
+- name: "Creating Service Accounts"
+  freeipa.ansible_freeipa.ipauser:
+    ipaadmin_password: "{{ ipaadmin_password }}"
+    name: "{{ item.name }}"
+    first: "{{ item.first }}"
+    last: "{{ item.last }}"
+    email: "{{ item.email }}"
+    password: "{{ item.password }}"
+    title: "{{ item.title }}"
+    loginshell: "{{ item.loginshell }}"
+    update_password: on_create
+  loop: "{{ svcusers }}"
+  tags:
+    - users

--- a/ansible/playbooks/init-rocky-ipa-internal-dns.yml
+++ b/ansible/playbooks/init-rocky-ipa-internal-dns.yml
@@ -3,6 +3,7 @@
 - name: Create our initial users
   hosts: ipaserver
   become: false
+  gather_facts: false
   vars_files:
   - vars/encpass.yml
   - vars/rdns.yml

--- a/ansible/playbooks/init-rocky-ipa-team.yml
+++ b/ansible/playbooks/init-rocky-ipa-team.yml
@@ -3,11 +3,14 @@
 - name: Create our initial users
   hosts: ipaserver
   become: false
+  gather_facts: false
   vars_files:
   - vars/encpass.yml
   - vars/users.yml
   - vars/adminusers.yml
+  - vars/svcusers.yml
   - vars/groups.yml
+  - vars/ipaprivs.yml
 
   tasks:
     - name: "Checking for user variables"
@@ -27,3 +30,6 @@
 
     - name: "Start sudo for admins"
       import_tasks: import-rockysudo.yml
+
+    - name: "Start privileges for services"
+      import_tasks: import-rockyipaprivs.yml

--- a/ansible/playbooks/vars/adminusers.yml
+++ b/ansible/playbooks/vars/adminusers.yml
@@ -63,3 +63,10 @@ adminusers:
     password: ThisIsNotMyPassword1!
     title: Infrastructure Manager
     loginshell: /bin/bash
+  - name: bagner2
+    first: Benjamin
+    last: Agner
+    email: bagner@rockylinux.org
+    password: ThisIsNotMyPassword1!
+    title: Security Director
+    loginshell: /bin/bash

--- a/ansible/playbooks/vars/ipaprivs.yml
+++ b/ansible/playbooks/vars/ipaprivs.yml
@@ -1,0 +1,28 @@
+---
+# privileges
+ipaprivileges:
+  - privilege: Privileges - Kerberos Managers
+    description: Kerberos Key Managers
+    permissions:
+      - "System: Manage Host Keytab"
+      - "System: Manage Host Keytab Permissions"
+      - "System: Manage Service Keytab"
+      - "System: Manage Service Keytab Permissions"
+      - "System: Manage User Principals"
+    role: Kerberos Managers
+    user:
+      - kerbman
+
+# Standalone Roles
+iparoles:
+  - role: IPA Client Managers
+    description: IPA Client Managers
+    privileges:
+      - "DNS Administrators"
+      - "DNS Servers"
+      - "Host Administrators"
+      - "Host Enrollment"
+      - "Host Group Administrators"
+      - "Netgroups Administrators"
+    user:
+      - hostman

--- a/ansible/playbooks/vars/svcusers.yml
+++ b/ansible/playbooks/vars/svcusers.yml
@@ -1,0 +1,16 @@
+---
+svcusers:
+  - name: hostman
+    first: Host
+    last: Manager
+    email: hostman@rockylinux.org
+    password: ThisIsNotMyPassword1!
+    title: System Account - Host Manager
+    loginshell: /sbin/nologin
+  - name: kerbman
+    first: Kerberos
+    last: Manager
+    email: kerbman@rockylinux.org
+    password: ThisIsNotMyPassword1!
+    title: System Account - Kerberos Key Manager
+    loginshell: /sbin/nologin

--- a/ansible/playbooks/vars/users.yml
+++ b/ansible/playbooks/vars/users.yml
@@ -63,3 +63,10 @@ users:
     password: ThisIsNotMyPassword1!
     title: Infrastructure Manager
     loginshell: /bin/bash
+  - name: bagner
+    first: Benjamin
+    last: Agner
+    email: bagner@rockylinux.org
+    password: ThisIsNotMyPassword1!
+    title: Security Director
+    loginshell: /bin/bash

--- a/ansible/roles/requirements.yml
+++ b/ansible/roles/requirements.yml
@@ -17,3 +17,4 @@ collections:
   - name: community.general
   - name: community.mysql
   - name: ansible.posix
+  - name: ktdreyer.koji_ansible


### PR DESCRIPTION
This release does the following:

-> Adds in privilege and role support
-> Adds in service accounts that are needed for koji
-> Adds in service accounts to have specialized accounts instead of using "admin" account beyond initial deployment

Testing is complete and functions in the lab.