### PR TITLE
Add automation for bootstrapping an openQA developer box

### DIFF
--- a/ansible/playbooks/init-rocky-openqa-developer-host.yml
+++ b/ansible/playbooks/init-rocky-openqa-developer-host.yml
@@ -1,0 +1,40 @@
+# Sets up local OpenQA testing environment
+# This playbook is *NOT* intended for WAN-facing systems!
+# Created: @akatch
+---
+- name: Rocky OpenQA Runbook
+  hosts: localhost
+  connection: local
+  become: true
+  vars_files:
+    - vars/openqa.yml
+
+  # This is to try to avoid the handler issue in pre/post tasks
+  handlers:
+    - import_tasks: handlers/main.yml
+
+  pre_tasks:
+    - name: Check if ansible cannot be run here
+      stat:
+        path: /etc/no-ansible
+      register: no_ansible
+
+    - name: Verify if we can run ansible
+      assert:
+        that:
+          - "not no_ansible.stat.exists"
+        success_msg: "We are able to run on this node"
+        fail_msg: "/etc/no-ansible exists - skipping run on this node"
+
+  tasks:
+    - name: Install and configure OpenQA
+      import_tasks: tasks/openqa.yml
+
+  post_tasks:
+    - name: Touching run file that ansible has ran here
+      file:
+        path: /var/log/ansible.run
+        state: touch
+        mode: '0644'
+        owner: root
+        group: root

--- a/ansible/playbooks/tasks/openqa.yml
+++ b/ansible/playbooks/tasks/openqa.yml
@@ -10,8 +10,8 @@
     src: /etc/httpd/conf.d/{{ item }}.template
     dest: /etc/httpd/conf.d/{{ item }}
   loop:
-  - openqa.conf
-  - openqa-ssl.conf
+    - openqa.conf
+    - openqa-ssl.conf
   notify: restart_httpd
 
 - name: Template OpenQA configuration files
@@ -22,15 +22,11 @@
     group: "{{ openqa_group }}"
     mode: "0444"
   loop:
-  - openqa.ini
-  - client.conf
+    - openqa.ini
+    - client.conf
 
-- name: Check for running postgresql
-  command: systemctl is-active postgresql
-  register: postgresql_is_running
-  check_mode: false
-  failed_when: false
-  changed_when: false
+- name: Get service facts
+  service_facts:
 
 - name: Check for non-empty postgres data directory
   stat:
@@ -39,17 +35,22 @@
 
 - name: If postgresql is not already running, initialize database
   command: postgresql-setup --initdb
-  when: not ( postgresql_is_running.stdout == "active" ) and not postgres_data_dir.stat.exists
+  when: not ( ansible_facts.services["postgresql.service"]["state"] == "running" )
+        and not postgres_data_dir.stat.exists
 
 - name: Enable and start postgresql service
   systemd:
-    name: "{{ item }}"
+    name: postgresql
     state: started
     enabled: true
-  when: not ( postgresql_is_running.stdout == "active" ) and not postgres_data_dir.stat.exists
+  when: not ( ansible_facts.services["postgresql.service"]["state"] == "running" )
+        and not postgres_data_dir.stat.exists
 
 - name: Configure SELinux to allow httpd connection to network
-  command: setsebool -P httpd_can_network_connect 1
+  seboolean:
+    name: httpd_can_network_connect
+    state: true
+    persistent: true
 
 - name: Enable and start OpenQA services
   systemd:
@@ -58,17 +59,14 @@
     enabled: true
   loop: "{{ openqa_services }}"
 
-- name: Permit http traffic
+- name: Permit traffic for {{ item }} service
   ansible.posix.firewalld:
-    service: http
+    service: "{{ item }}"
     permanent: true
     state: enabled
-
-- name: Enable VNC firewalld service
-  ansible.posix.firewalld:
-    service: openqa-vnc
-    permanent: true
-    state: enabled
+  loop:
+    - httpd
+    - openqa-vnc
 
 - name: Permit VNC traffic for local workers
   ansible.posix.firewalld:
@@ -77,7 +75,9 @@
     state: enabled
 
 - name: Reload FirewallD
-  command: firewall-cmd --reload
+  systemd:
+    name: firewalld
+    state: reloaded
 
 - name: Check for existing repository
   stat:
@@ -121,10 +121,10 @@
     group: "{{ openqa_group }}"
     mode: "0775"
   loop:
-  - CHECKSUM
-  - Rocky-{{ rocky_version }}-{{ rocky_arch }}-boot.iso
-  - Rocky-{{ rocky_version }}-{{ rocky_arch }}-dvd1.iso
-  - Rocky-{{ rocky_version }}-{{ rocky_arch }}-minimal.iso
+    - CHECKSUM
+    - Rocky-{{ rocky_version }}-{{ rocky_arch }}-boot.iso
+    - Rocky-{{ rocky_version }}-{{ rocky_arch }}-dvd1.iso
+    - Rocky-{{ rocky_version }}-{{ rocky_arch }}-minimal.iso
 
 - name: Verify ISO checksums
   command: shasum -a 256 --ignore-missing -c CHECKSUM

--- a/ansible/playbooks/tasks/openqa.yml
+++ b/ansible/playbooks/tasks/openqa.yml
@@ -1,0 +1,148 @@
+---
+- name: Install OpenQA packages
+  yum:
+    name: "{{ openqa_packages }}"
+    state: present
+
+- name: Copy httpd configuration files
+  copy:
+    remote_src: true
+    src: /etc/httpd/conf.d/{{ item }}.template
+    dest: /etc/httpd/conf.d/{{ item }}
+  loop:
+  - openqa.conf
+  - openqa-ssl.conf
+  notify: restart_httpd
+
+- name: Template OpenQA configuration files
+  template:
+    src: etc/openqa/{{ item }}.j2
+    dest: /etc/openqa/{{ item }}
+    owner: "{{ openqa_user }}"
+    group: "{{ openqa_group }}"
+    mode: "0444"
+  loop:
+  - openqa.ini
+  - client.conf
+
+- name: Check for running postgresql
+  command: systemctl is-active postgresql
+  register: postgresql_is_running
+  check_mode: false
+  failed_when: false
+  changed_when: false
+
+- name: Check for non-empty postgres data directory
+  stat:
+    path: /var/lib/pgsql/data
+  register: postgres_data_dir
+
+- name: If postgresql is not already running, initialize database
+  command: postgresql-setup --initdb
+  when: not ( postgresql_is_running.stdout == "active" ) and not postgres_data_dir.stat.exists
+
+- name: Enable and start postgresql service
+  systemd:
+    name: "{{ item }}"
+    state: started
+    enabled: true
+  when: not ( postgresql_is_running.stdout == "active" ) and not postgres_data_dir.stat.exists
+
+- name: Configure SELinux to allow httpd connection to network
+  command: setsebool -P httpd_can_network_connect 1
+
+- name: Enable and start OpenQA services
+  systemd:
+    name: "{{ item }}"
+    state: started
+    enabled: true
+  loop: "{{ openqa_services }}"
+
+- name: Permit http traffic
+  ansible.posix.firewalld:
+    service: http
+    permanent: true
+    state: enabled
+
+- name: Enable VNC firewalld service
+  ansible.posix.firewalld:
+    service: openqa-vnc
+    permanent: true
+    state: enabled
+
+- name: Permit VNC traffic for local workers
+  ansible.posix.firewalld:
+    port: "{{ openqa_min_vnc_port }}-{{ openqa_max_vnc_port }}/tcp"
+    permanent: true
+    state: enabled
+
+- name: Reload FirewallD
+  command: firewall-cmd --reload
+
+- name: Check for existing repository
+  stat:
+    path: "{{ openqa_homedir }}/share/tests/rocky"
+  register: rocky_testing_repo
+
+- name: Clone repository if it does not already exist
+  git:
+    accept_hostkey: true
+    dest: "{{ openqa_homedir }}/share/tests/rocky"
+    repo: "{{ openqa_rocky_testing_repo }}"
+    version: develop
+  when: not rocky_testing_repo.stat.exists
+
+- name: Set permissions on repo dir
+  file:
+    path: "{{ openqa_homedir }}/share/tests/rocky"
+    recurse: true
+    owner: "{{ openqa_user }}"
+    group: "{{ openqa_group }}"
+    mode: "0775"
+
+- name: Run fifloader.py
+  command: ./fifloader.py -l -c templates.fif.json templates-updates.fif.json
+  args:
+    chdir: "{{ openqa_homedir }}/share/tests/rocky"
+
+- name: Create ISO directory
+  file:
+    path: "{{ openqa_homedir }}/share/factory/iso/fixed"
+    state: directory
+    owner: "{{ openqa_user }}"
+    group: "{{ openqa_group }}"
+    mode: "0775"
+
+- name: Download ISOs
+  get_url:
+    dest: "{{ openqa_homedir }}/share/factory/iso/fixed/"
+    url: "{{ rocky_iso_download_url }}/{{ item }}"
+    owner: "{{ openqa_user }}"
+    group: "{{ openqa_group }}"
+    mode: "0775"
+  loop:
+  - CHECKSUM
+  - Rocky-{{ rocky_version }}-{{ rocky_arch }}-boot.iso
+  - Rocky-{{ rocky_version }}-{{ rocky_arch }}-dvd1.iso
+  - Rocky-{{ rocky_version }}-{{ rocky_arch }}-minimal.iso
+
+- name: Verify ISO checksums
+  command: shasum -a 256 --ignore-missing -c CHECKSUM
+  args:
+    chdir: "{{ openqa_homedir }}/share/factory/iso/fixed"
+
+- name: Start OpenQA worker
+  ansible.builtin.systemd:
+    name: "openqa-worker@1"
+    state: started
+    enabled: true
+
+- name: POST a job
+  command: |
+    openqa-cli api -X POST isos \
+      ISO=Rocky-{{ rocky_version }}-{{ rocky_arch }}-minimal.iso \
+      ARCH={{ rocky_arch }} \
+      DISTRI=rocky \
+      FLAVOR=minimal-iso \
+      VERSION={{ rocky_version }} \
+      BUILD="{{ '%Y%m%d.%H%M%S' | strftime }}.0"

--- a/ansible/playbooks/templates/etc/openqa/client.conf.j2
+++ b/ansible/playbooks/templates/etc/openqa/client.conf.j2
@@ -1,0 +1,3 @@
+[{{ openqa_host }}]
+key = {{ openqa_client_key }}
+secret = {{ openqa_client_secret }}

--- a/ansible/playbooks/templates/etc/openqa/openqa.ini.j2
+++ b/ansible/playbooks/templates/etc/openqa/openqa.ini.j2
@@ -1,0 +1,6 @@
+[global]
+branding=plain
+download_domains = rockylinux.org fedoraproject.org opensuse.org
+
+[auth]
+method = Fake

--- a/ansible/playbooks/vars/openqa.yml
+++ b/ansible/playbooks/vars/openqa.yml
@@ -1,0 +1,67 @@
+---
+# Default OpenQA user and group
+openqa_user: geekotest
+openqa_group: geekotest
+
+# OpenQA data directory
+openqa_homedir: /var/lib/openqa
+
+# URL for the repository containing the RockyLinux test automation
+openqa_rocky_testing_repo: "https://github.com/rocky-linux/os-autoinst-distri-rocky.git"
+
+# The RockyLinux version to fetch for testing
+rocky_version: 8.4
+
+# The RockyLinux architecture to fetch for testing
+rocky_arch: x86_64
+
+# Public download URL for RockyLinux ISOs
+rocky_iso_download_url: "https://download.rockylinux.org/pub/rocky/8/isos/{{ rocky_arch }}"
+
+# The host the openqa-cli should access when it runs.
+# Change this if you want to access your OpenQA via an
+# alternative URL
+openqa_host: localhost
+
+# These are the default client credentials.
+# They will expire 24 hours after installation and must
+# be replaced with new ones.
+openqa_client_key: 1234567890ABCDEF
+openqa_client_secret: 1234567890ABCDEF
+
+# The number of workers to enable on this system
+openqa_worker_count: 1
+
+# Port range to open for VNC access to local workers.
+# The max port should be 5990 + n where n is the total
+# number of workers you want to enable on your system.
+openqa_min_vnc_port: 5991
+openqa_max_vnc_port: "{{ 5990 + openqa_worker_count|int }}"
+
+# Packages to install
+openqa_packages:
+- git
+- vim-enhanced
+- openqa
+- openqa-httpd
+- openqa-worker
+- fedora-messaging
+- guestfs-tools
+- libguestfs-xfs
+- python3-fedfind
+- python3-libguestfs
+- libvirt-daemon-config-network
+- virt-install
+- withlock
+- postgresql-server
+- perl-REST-Client
+
+# Services to start and enable
+openqa_services:
+- sshd
+- httpd
+- openqa-gru
+- openqa-scheduler
+- openqa-websockets
+- openqa-webui
+- fm-consumer@fedora_openqa_scheduler


### PR DESCRIPTION
This PR adds the playbook `init-rocky-openqa-developer-host.yml`, to be used for bootstrapping developer instances of OpenQA. This playbook mostly follows the automation from [this repo](https://github.com/rocky-linux/OpenQA-Fedora-Installation).