### PR TITLE
Openqa dev demo fixes

### DIFF
--- a/ansible/playbooks/tasks/openqa.yml
+++ b/ansible/playbooks/tasks/openqa.yml
@@ -141,11 +141,14 @@
   args:
     chdir: "{{ openqa_homedir }}/share/factory/iso/fixed"
 
-- name: Start OpenQA worker
+- name: Start {{ openqa_worker_count }} OpenQA workers
   ansible.builtin.systemd:
-    name: "openqa-worker@1"
+    name: "openqa-worker@{{ item }}"
     state: started
     enabled: true
+  # range 'end' parameter is exclusive, so add 1
+  loop: "{{ range(1, (openqa_worker_count|int + 1)) | list }}"
+  tags: start_workers
 
 - name: POST a job
   command: |

--- a/ansible/playbooks/tasks/openqa.yml
+++ b/ansible/playbooks/tasks/openqa.yml
@@ -33,7 +33,7 @@
 
 - name: Check for non-empty postgres data directory
   stat:
-    path: /var/lib/pgsql/data
+    path: /var/lib/pgsql/data/base
   register: postgres_data_dir
 
 - name: If postgresql is not already running, initialize database
@@ -68,7 +68,7 @@
     permanent: true
     state: enabled
   loop:
-    - httpd
+    - http
     - openqa-vnc
 
 - name: Permit VNC traffic for local workers
@@ -102,6 +102,11 @@
     owner: "{{ openqa_user }}"
     group: "{{ openqa_group }}"
     mode: "0775"
+
+# fifloader.py will fail if the Demo user is not logged in
+- name: Authenticate to web UI the first time
+  uri:
+    url: "http://{{ openqa_host }}/login"
 
 - name: Run fifloader.py
   command: ./fifloader.py -l -c templates.fif.json templates-updates.fif.json


### PR DESCRIPTION
While prepping for my demo of this automation to the testing team, I identified a few issues that are resolved with this PR. The reason I did not catch these issues previously is that my process for blowing away my local openQA installation was incomplete - that is no longer the case.

Fixes:
- FirewallD service name is `http`, not `httpd`
- Check for existing postgres installation now looks for the existence of /var/lib/pgsql/data/base rather than the parent directory of the former, which may exist but be empty after the package is installed but before the database is initialized
- Automation will now "log in" to the web UI prior to running `fifloader.py`

Enhancements:
- Task for starting openqa-worker instances will now honor `openqa_worker_count` if the default of 1 is overridden