### PR TITLE
Remove openqa-vnc firewall service as ports get directly added

### DIFF
--- a/ansible/playbooks/tasks/openqa.yml
+++ b/ansible/playbooks/tasks/openqa.yml
@@ -69,7 +69,6 @@
     state: enabled
   loop:
     - http
-    - openqa-vnc
 
 - name: Permit VNC traffic for local workers
   ansible.posix.firewalld:


### PR DESCRIPTION
As we found out while testing the installation, the `openqa-vnc` service was created in the originating shell-script.
This is done in this script now with directly adding the ports, so the addition of the service can and has to be removed.