### PR TITLE
Fix openqa iso download and repo permissions

### DIFF
--- a/ansible/playbooks/tasks/openqa.yml
+++ b/ansible/playbooks/tasks/openqa.yml
@@ -95,13 +95,13 @@
     version: develop
   when: not rocky_testing_repo.stat.exists
 
-- name: Set permissions on repo dir
+- name: Set owner/group/permissions on repo contents
   file:
     path: "{{ openqa_homedir }}/share/tests/rocky"
     recurse: true
     owner: "{{ openqa_user }}"
     group: "{{ openqa_group }}"
-    mode: "0775"
+    mode: "u+rwX,g+rwX,o+rX,o-w"
 
 # fifloader.py will fail if the Demo user is not logged in
 - name: Authenticate to web UI the first time

--- a/ansible/playbooks/tasks/openqa.yml
+++ b/ansible/playbooks/tasks/openqa.yml
@@ -124,22 +124,14 @@
 
 - name: Download ISOs
   get_url:
-    dest: "{{ openqa_homedir }}/share/factory/iso/fixed/"
-    url: "{{ rocky_iso_download_url }}/{{ item }}"
+    dest: "{{ openqa_homedir }}/share/factory/iso/fixed/{{ item.name }}"
+    url: "{{ rocky_iso_download_url }}/{{ item.name }}"
+    checksum: "{{ item.checksum }}"
     owner: "{{ openqa_user }}"
     group: "{{ openqa_group }}"
-    mode: "0775"
-  loop:
-    - CHECKSUM
-    - Rocky-{{ rocky_version }}-{{ rocky_arch }}-boot.iso
-    - Rocky-{{ rocky_version }}-{{ rocky_arch }}-dvd1.iso
-    - Rocky-{{ rocky_version }}-{{ rocky_arch }}-minimal.iso
-
-- name: Verify ISO checksums
-  command: shasum -a 256 --ignore-missing -c CHECKSUM
-  changed_when: "1 != 1"
-  args:
-    chdir: "{{ openqa_homedir }}/share/factory/iso/fixed"
+    tmp_dest: "/var/tmp"
+    mode: "0644"
+  loop: "{{ openqa_isos }}"
 
 - name: Start {{ openqa_worker_count }} OpenQA workers
   ansible.builtin.systemd:

--- a/ansible/playbooks/vars/openqa.yml
+++ b/ansible/playbooks/vars/openqa.yml
@@ -18,6 +18,15 @@ rocky_arch: x86_64
 # Public download URL for RockyLinux ISOs
 rocky_iso_download_url: "https://download.rockylinux.org/pub/rocky/8/isos/{{ rocky_arch }}"
 
+# Rocky Linux ISOs
+openqa_isos:
+  - name: "Rocky-{{ rocky_version }}-{{ rocky_arch }}-boot.iso"
+    checksum: "sha256:53a62a72881b931bdad6b13bcece7c3a2d4ca9c4a2f1e1a8029d081dd25ea61f"
+  - name: "Rocky-{{ rocky_version }}-{{ rocky_arch }}-dvd1.iso"
+    checksum: "sha256:ffe2fae67da6702d859cfb0b321561a5d616ce87a963d8a25b018c9c3d52d9a4"
+  - name: "Rocky-{{ rocky_version }}-{{ rocky_arch }}-minimal.iso"
+    checksum: "sha256:0de5f12eba93e00fefc06cdb0aa4389a0972a4212977362ea18bde46a1a1aa4f"
+
 # The host the openqa-cli should access when it runs.
 # Change this if you want to access your OpenQA via an
 # alternative URL


### PR DESCRIPTION
The following improvements are made:

**repo permissions**
- don't explicitly set all files executable
- provide write access to tests for members of `geekotest` group

**ISO download**
- validate ISO checksum using builtin functionality of Ansible `get_url` built-in
- download is skipped if local file exists and checksum is valid
- `tmp_dest: /var/tmp` redirects temporary download to avoid out-of-space error
- ISO filenames and checksums moved to `vars/openqa.yaml`

