### PR TITLE
Create openqa-vnc service to prevent conflict

### DIFF
--- a/ansible/playbooks/tasks/openqa.yml
+++ b/ansible/playbooks/tasks/openqa.yml
@@ -62,6 +62,19 @@
     enabled: true
   loop: "{{ openqa_services }}"
 
+- name: Create openqa-vnc firewalld service
+  template:
+    src: etc/firewalld/services/openqa-vnc.xml.j2
+    dest: /etc/firewalld/services/openqa-vnc.xml
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Load openqa-vnc firewalld service
+  systemd:
+    name: firewalld
+    state: reloaded
+
 - name: Permit traffic for {{ item }} service
   ansible.posix.firewalld:
     service: "{{ item }}"
@@ -69,12 +82,7 @@
     state: enabled
   loop:
     - http
-
-- name: Permit VNC traffic for local workers
-  ansible.posix.firewalld:
-    port: "{{ openqa_min_vnc_port }}-{{ openqa_max_vnc_port }}/tcp"
-    permanent: true
-    state: enabled
+    - openqa-vnc
 
 - name: Reload FirewallD
   systemd:

--- a/ansible/playbooks/templates/etc/firewalld/services/openqa-vnc.xml.j2
+++ b/ansible/playbooks/templates/etc/firewalld/services/openqa-vnc.xml.j2
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <port port="{{ openqa_min_vnc_port }}-{{ openqa_max_vnc_port }}" protocol="tcp"/>
+</service>


### PR DESCRIPTION
Create a firewalld service to open the ports for VNC traffic. This prevents ansible from creating an invalid firewalld configuration and bringing down networking on Fedora 34 workstation due to overlapping ports.

Reported issue with `ansible.posix.firewalld` allowing invalid configuration here:
https://github.com/ansible-collections/ansible.posix/issues/269