### PR TITLE
Automation for configuring openQA multi-VM networking

### DIFF
--- a/ansible/playbooks/handlers/openqa.yml
+++ b/ansible/playbooks/handlers/openqa.yml
@@ -1,0 +1,36 @@
+---
+- name: reload_firewalld
+  systemd:
+    name: firewalld
+    state: reloaded
+
+# restart os-autoinst-openvswitch followed immediately by `network` (not NetworkManager)
+- name: restart_os-autoinst-openvswitch
+  systemd:
+    name: os-autoinst-openvswitch
+    state: restarted
+
+- name: restart_network
+  systemd:
+    name: network
+    state: restarted
+  listen: restart_os-autoinst-openvswitch
+
+- name: restart_openqa_services
+  systemd:
+    name: "{{ item }}"
+    state: restarted
+  loop:
+    - openqa-gru
+    - openqa-scheduler
+    - openqa-websockets
+    - openqa-webui
+    - fm-consumer@fedora_openqa_scheduler
+
+- name: restart_openqa_workers
+  systemd:
+    name: "openqa-worker@{{ item }}"
+    state: restarted
+  loop: "{{ range(openqa_worker_count) | list }}"
+  listen: restart_openqa_services
+...

--- a/ansible/playbooks/init-rocky-openqa-developer-host.yml
+++ b/ansible/playbooks/init-rocky-openqa-developer-host.yml
@@ -42,6 +42,11 @@
     - name: Install and configure OpenQA
       import_tasks: tasks/openqa.yml
 
+    - name: Install and configure OpenQA multivm networking
+      import_tasks: tasks/openqa-multivm-networking.yml
+      when: openqa_worker_count|int > 1
+      tags: multivm
+
   post_tasks:
     - name: Touching run file that ansible has ran here
       file:

--- a/ansible/playbooks/init-rocky-openqa-developer-host.yml
+++ b/ansible/playbooks/init-rocky-openqa-developer-host.yml
@@ -23,7 +23,7 @@
 
   # This is to try to avoid the handler issue in pre/post tasks
   handlers:
-    - import_tasks: handlers/main.yml
+    - import_tasks: handlers/openqa.yml
 
   pre_tasks:
     - name: Check if ansible cannot be run here

--- a/ansible/playbooks/remove-rocky-openqa-developer-host.yml
+++ b/ansible/playbooks/remove-rocky-openqa-developer-host.yml
@@ -1,0 +1,40 @@
+# Delete local OpenQA testing environment
+# This playbook is *NOT* intended for WAN-facing systems!
+# Created: @akatch
+---
+- name: Rocky OpenQA Runbook
+  hosts: localhost
+  connection: local
+  become: true
+  vars_files:
+    - vars/openqa.yml
+
+  # This is to try to avoid the handler issue in pre/post tasks
+  handlers:
+    - import_tasks: handlers/main.yml
+
+  pre_tasks:
+    - name: Check if ansible cannot be run here
+      stat:
+        path: /etc/no-ansible
+      register: no_ansible
+
+    - name: Verify if we can run ansible
+      assert:
+        that:
+          - "not no_ansible.stat.exists"
+        success_msg: "We are able to run on this node"
+        fail_msg: "/etc/no-ansible exists - skipping run on this node"
+
+  tasks:
+    - name: Remove OpenQA installation from this system
+      import_tasks: tasks/remove_openqa.yml
+
+  post_tasks:
+    - name: Touching run file that ansible has ran here
+      file:
+        path: /var/log/ansible.run
+        state: touch
+        mode: '0644'
+        owner: root
+        group: root

--- a/ansible/playbooks/remove-rocky-openqa-multivm-networking.yml
+++ b/ansible/playbooks/remove-rocky-openqa-multivm-networking.yml
@@ -1,0 +1,53 @@
+# Sets up local OpenQA testing environment
+# This playbook is *NOT* intended for WAN-facing systems!
+#
+# Usages:
+#   # Install and configure an openQA developer host, download all current Rocky ISOs,
+#   # and POST a test job
+#   ansible-playbook playbooks/init-rocky-openqa-developer-host.yml
+#
+#   # Only perform ISO download tasks
+#   ansible-playbook playbooks/init-rocky-openqa-developer-host.yml --tags=download_isos
+#
+#   # Only perform configuration, do not download ISOs or POST a job
+#   ansible-playbook playbooks/init-rocky-openqa-developer-host.yml --tags=configure
+#
+# Created: @akatch
+---
+- name: Rocky OpenQA Runbook
+  hosts: localhost
+  connection: local
+  become: true
+  vars_files:
+    - vars/openqa.yml
+
+  # This is to try to avoid the handler issue in pre/post tasks
+  handlers:
+    - import_tasks: handlers/main.yml
+
+  pre_tasks:
+    - name: Check if ansible cannot be run here
+      stat:
+        path: /etc/no-ansible
+      register: no_ansible
+
+    - name: Verify if we can run ansible
+      assert:
+        that:
+          - "not no_ansible.stat.exists"
+        success_msg: "We are able to run on this node"
+        fail_msg: "/etc/no-ansible exists - skipping run on this node"
+
+  tasks:
+    - name: Remove openqa multivm networking configs
+      import_tasks: tasks/remove_openqa-multivm-networking.yml
+
+  post_tasks:
+    - name: Touching run file that ansible has ran here
+      file:
+        path: /var/log/ansible.run
+        state: touch
+        mode: '0644'
+        owner: root
+        group: root
+...

--- a/ansible/playbooks/tasks/openqa-multivm-networking.yml
+++ b/ansible/playbooks/tasks/openqa-multivm-networking.yml
@@ -1,4 +1,12 @@
 ---
+# {{ openqa_multivm_bridge_interface }} should not exist or we should use a different name
+- name: Assert {{ openqa_multivm_bridge_interface }} does not exist
+  assert:
+    that:
+      - 'openqa_multivm_bridge_interface not in ansible_interfaces'
+    success_msg: 'interface does not exist, can proceed'
+    fail_msg: '{{ openqa_multivm_bridge_interface }} already exists, please supply an alternative'
+
 - name: dnf install os-autoinst-openvswitch tunctl network-scripts
   dnf:
     pkg:
@@ -12,20 +20,22 @@
     content: |
       OS_AUTOINST_BRIDGE_LOCAL_IP=172.16.2.2
       OS_AUTOINST_BRIDGE_REWRITE_TARGET=172.17.0.0
+      OS_AUTOINST_USE_BRIDGE={{ openqa_multivm_bridge_interface }}
+  notify: restart_os-autoinst-openvswitch
 
-- name: create /etc/sysconfig/network-scripts/br0
+- name: create /etc/sysconfig/network-scripts/ifcfg-{{ openqa_multivm_bridge_interface }}
   copy:
-    dest: /etc/sysconfig/network-scripts/ifcfg-br0
+    dest: /etc/sysconfig/network-scripts/ifcfg-{{ openqa_multivm_bridge_interface }}
     content: |
       DEVICETYPE='ovs'
       TYPE='OVSBridge'
       BOOTPROTO='static'
       IPADDR='172.16.2.2'
       NETMASK='255.254.0.0'
-      DEVICE=br0
+      DEVICE={{ openqa_multivm_bridge_interface }}
       STP=off
       ONBOOT='yes'
-      NAME='br0'
+      NAME='{{ openqa_multivm_bridge_interface }}'
       HOTPLUG='no'
 
 - name: create worker tap interface configs
@@ -34,14 +44,13 @@
     content: |
       DEVICETYPE='ovs'
       TYPE='OVSPort'
-      OVS_BRIDGE='br0'
+      OVS_BRIDGE='{{ openqa_multivm_bridge_interface }}'
       DEVICE='tap{{ item }}'
       ONBOOT='yes'
       BOOTPROTO='none'
       HOTPLUG='no'
   loop: "{{ range(openqa_worker_count) | list }}"
 
-# TODO is this needed for single-machine multivm setups?
 - name: Update /sbin/ifup-pre-local
   template:
     src: sbin/ifup-pre-local.j2
@@ -51,9 +60,10 @@
 - name: Enable bridge interface for internal zone
   ansible.posix.firewalld:
     permanent: true
-    interface: br0
+    interface: '{{ openqa_multivm_bridge_interface }}'
     state: enabled
     zone: internal
+  notify: reload_firewalld
 
 - name: Enable masquerade for public and internal zones
   ansible.posix.firewalld:
@@ -64,6 +74,7 @@
   loop:
     - public
     - internal
+  notify: reload_firewalld
 
 - name: Enable ipv4 IP forwarding
   sysctl:
@@ -79,8 +90,9 @@
     state: present
     zone: public
     target: ACCEPT
+  notify: reload_firewalld
 
-# TODO is this needed for single-machine multivm setups?
+# Only needed for multi-host setups
 - name: add port for GRE tunnel
   ansible.posix.firewalld:
     permanent: true
@@ -88,7 +100,7 @@
     state: enabled
 
 - name: Enable openvswitch services
-  ansible.builtin.systemd:
+  systemd:
     name: "{{ item }}"
     state: started
     enabled: true
@@ -98,11 +110,6 @@
     - os-autoinst-openvswitch
   ignore_errors: "{{ ansible_check_mode }}"
 
-- name: Reload FirewallD
-  systemd:
-    name: firewalld
-    state: reloaded
-
 - name: Set WORKER_CLASS for tap interfaces
   community.general.ini_file:
     path: /etc/openqa/workers.ini
@@ -110,6 +117,11 @@
     option: WORKER_CLASS
     value: qemu_x86_64,tap
     state: present
+  notify: restart_openqa_services
 
-- command: ovs-vsctl --may-exist add-br br0
-- command: setcap CAP_NET_ADMIN=ep /usr/bin/qemu-system-x86_64
+- name: Enable bridge {{ openqa_multivm_bridge_interface }} for openvswitch
+  command: ovs-vsctl add-br {{ openqa_multivm_bridge_interface }}
+
+- name: Enable capability
+  command: setcap CAP_NET_ADMIN=ep /usr/bin/qemu-system-x86_64
+...

--- a/ansible/playbooks/tasks/openqa-multivm-networking.yml
+++ b/ansible/playbooks/tasks/openqa-multivm-networking.yml
@@ -1,0 +1,115 @@
+---
+- name: dnf install os-autoinst-openvswitch tunctl network-scripts
+  dnf:
+    pkg:
+      - os-autoinst-openvswitch
+      - tunctl
+      - network-scripts
+
+- name: create /etc/sysconfig/os-autoinst-openvswitch
+  copy:
+    dest: /etc/sysconfig/os-autoinst-openvswitch
+    content: |
+      OS_AUTOINST_BRIDGE_LOCAL_IP=172.16.2.2
+      OS_AUTOINST_BRIDGE_REWRITE_TARGET=172.17.0.0
+
+- name: create /etc/sysconfig/network-scripts/br0
+  copy:
+    dest: /etc/sysconfig/network-scripts/ifcfg-br0
+    content: |
+      DEVICETYPE='ovs'
+      TYPE='OVSBridge'
+      BOOTPROTO='static'
+      IPADDR='172.16.2.2'
+      NETMASK='255.254.0.0'
+      DEVICE=br0
+      STP=off
+      ONBOOT='yes'
+      NAME='br0'
+      HOTPLUG='no'
+
+- name: create worker tap interface configs
+  copy:
+    dest: /etc/sysconfig/network-scripts/ifcfg-tap{{ item }}
+    content: |
+      DEVICETYPE='ovs'
+      TYPE='OVSPort'
+      OVS_BRIDGE='br0'
+      DEVICE='tap{{ item }}'
+      ONBOOT='yes'
+      BOOTPROTO='none'
+      HOTPLUG='no'
+  loop: "{{ range(openqa_worker_count) | list }}"
+
+# TODO is this needed for single-machine multivm setups?
+- name: Update /sbin/ifup-pre-local
+  template:
+    src: sbin/ifup-pre-local.j2
+    dest: /sbin/ifup-pre-local
+    mode: 'ug+x'
+
+- name: Enable bridge interface for internal zone
+  ansible.posix.firewalld:
+    permanent: true
+    interface: br0
+    state: enabled
+    zone: internal
+
+- name: Enable masquerade for public and internal zones
+  ansible.posix.firewalld:
+    masquerade: true
+    permanent: true
+    state: enabled
+    zone: '{{ item }}'
+  loop:
+    - public
+    - internal
+
+- name: Enable ipv4 IP forwarding
+  sysctl:
+    name: net.ipv4.ip_forward
+    value: '1'
+    state: present
+    sysctl_file: /etc/sysctl.d/ip-forward.conf
+    sysctl_set: true
+
+- name: set-target ACCEPT on public zone
+  ansible.posix.firewalld:
+    permanent: true
+    state: present
+    zone: public
+    target: ACCEPT
+
+# TODO is this needed for single-machine multivm setups?
+- name: add port for GRE tunnel
+  ansible.posix.firewalld:
+    permanent: true
+    port: 1723/tcp
+    state: enabled
+
+- name: Enable openvswitch services
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    state: started
+    enabled: true
+  loop:
+    - openvswitch
+    - network
+    - os-autoinst-openvswitch
+  ignore_errors: "{{ ansible_check_mode }}"
+
+- name: Reload FirewallD
+  systemd:
+    name: firewalld
+    state: reloaded
+
+- name: Set WORKER_CLASS for tap interfaces
+  community.general.ini_file:
+    path: /etc/openqa/workers.ini
+    section: global
+    option: WORKER_CLASS
+    value: qemu_x86_64,tap
+    state: present
+
+- command: ovs-vsctl --may-exist add-br br0
+- command: setcap CAP_NET_ADMIN=ep /usr/bin/qemu-system-x86_64

--- a/ansible/playbooks/tasks/remove_openqa-multivm-networking.yml
+++ b/ansible/playbooks/tasks/remove_openqa-multivm-networking.yml
@@ -1,0 +1,90 @@
+---
+- name: remove files
+  file:
+    path: '{{ item }}'
+    state: absent
+  loop:
+    - /etc/sysconfig/os-autoinst-openvswitch
+    - /etc/sysconfig/network-scripts/ifcfg-{{ openqa_multivm_bridge_interface }}
+
+- name: remove tap interface configurations
+  file:
+    path: /etc/sysconfig/network-scripts/ifcfg-tap{{ item }}
+    state: absent
+  loop: "{{ range(openqa_worker_count|int) | list }}"
+
+- name: Delete bridge interface
+  command: ovs-vsctl del-br {{ openqa_multivm_bridge_interface }}
+
+- name: Disable openvswitch services
+  ansible.builtin.systemd:
+    name: "{{ item }}"
+    state: stopped
+    enabled: false
+  loop:
+    - os-autoinst-openvswitch
+    - openvswitch
+
+- name: remove packages
+  dnf:
+    pkg:
+      - os-autoinst-openvswitch
+      - tunctl
+      - network-scripts
+    state: absent
+
+- name: Remove /sbin/ifup-pre-local
+  file:
+    path: /sbin/ifup-pre-local
+    state: absent
+
+- name: Disable bridge interface for internal zone
+  ansible.posix.firewalld:
+    permanent: true
+    interface: br0
+    state: disabled
+    zone: internal
+  notify: reload_firewalld
+
+- name: Disable masquerade for public and internal zones
+  ansible.posix.firewalld:
+    masquerade: true
+    permanent: true
+    state: disabled
+    zone: '{{ item }}'
+  loop:
+    - public
+    - internal
+  notify: reload_firewalld
+
+- name: Disable ipv4 IP forwarding
+  sysctl:
+    name: net.ipv4.ip_forward
+    value: '1'
+    state: absent
+    sysctl_file: /etc/sysctl.d/ip-forward.conf
+    sysctl_set: true
+
+- name: set-target ACCEPT on public zone
+  ansible.posix.firewalld:
+    permanent: true
+    state: absent
+    zone: public
+    target: ACCEPT
+  notify: reload_firewalld
+
+- name: Remove port for GRE tunnel
+  ansible.posix.firewalld:
+    permanent: true
+    port: 1723/tcp
+    state: disabled
+  notify: reload_firewalld
+
+- name: Set WORKER_CLASS for tap interfaces
+  community.general.ini_file:
+    path: /etc/openqa/workers.ini
+    section: global
+    option: WORKER_CLASS
+    value: qemu_x86_64,tap
+    state: absent
+...

--- a/ansible/playbooks/tasks/remove_openqa.yml
+++ b/ansible/playbooks/tasks/remove_openqa.yml
@@ -1,0 +1,42 @@
+---
+- name: Uninstall OpenQA packages
+  yum:
+    name: "{{ openqa_packages }}"
+    state: absent
+
+- name: Delete OpenQA files and directories
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ openqa_homedir }}"
+    - /var/lib/pgsql
+    - /etc/openqa
+    - /etc/httpd/conf.d/openqa.conf
+    - /etc/httpd/conf.d/openqa-ssl.conf
+
+- name: Disable httpd_can_network_connect
+  seboolean:
+    name: httpd_can_network_connect
+    state: false
+    persistent: true
+
+- name: Deny traffic for services
+  ansible.posix.firewalld:
+    service: "{{ item }}"
+    permanent: true
+    state: disabled
+  loop:
+    - http
+    - openqa-vnc
+
+- name: Deny VNC traffic for local workers
+  ansible.posix.firewalld:
+    port: "{{ openqa_min_vnc_port }}-{{ openqa_max_vnc_port }}/tcp"
+    permanent: true
+    state: disabled
+
+- name: Reload FirewallD
+  systemd:
+    name: firewalld
+    state: reloaded

--- a/ansible/playbooks/templates/sbin/ifup-pre-local.j2
+++ b/ansible/playbooks/templates/sbin/ifup-pre-local.j2
@@ -9,11 +9,12 @@ if [ "$iftype" == "tap" ]; then
     tunctl -u _openqa-worker -p -t "$if"
 fi
 
-# if the interface being brough up is br0, create
+# if the interface being brough up is {{ openqa_multivm_bridge_interface }}, create
 # the gre tunnels
-#if [ "$if" == "br0" ]; then
-#    ovs-vsctl set bridge br0 stp_enable=true
+if [ "$if" == "{{ openqa_multivm_bridge_interface }}" ]; then
+    ovs-vsctl set bridge {{ openqa_multivm_bridge_interface }} stp_enable=true
+    # This is only needed for multi-host setups
 {% for w in range(1, openqa_worker_count+1) %}
-#    ovs-vsctl --may-exist add-port br0 gre{{ w }} -- set interface gre{{ w }} type=gre options:remote_ip=172.16.2.{{ 2 + w|int }}
+    #ovs-vsctl --may-exist add-port {{ openqa_multivm_bridge_interface }} gre{{ w }} -- set interface gre{{ w }} type=gre options:remote_ip=172.16.2.{{ 2 + w|int }}
 {% endfor %}
-#fi
+fi

--- a/ansible/playbooks/templates/sbin/ifup-pre-local.j2
+++ b/ansible/playbooks/templates/sbin/ifup-pre-local.j2
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+if=$(echo "$1" | sed -e 's,ifcfg-,,')
+iftype=$(echo "$if" | sed -e 's,[0-9]\+$,,')
+
+# if the interface being brought up is tap[n], create
+# the tap device first
+if [ "$iftype" == "tap" ]; then
+    tunctl -u _openqa-worker -p -t "$if"
+fi
+
+# if the interface being brough up is br0, create
+# the gre tunnels
+#if [ "$if" == "br0" ]; then
+#    ovs-vsctl set bridge br0 stp_enable=true
+{% for w in range(1, openqa_worker_count+1) %}
+#    ovs-vsctl --may-exist add-port br0 gre{{ w }} -- set interface gre{{ w }} type=gre options:remote_ip=172.16.2.{{ 2 + w|int }}
+{% endfor %}
+#fi

--- a/ansible/playbooks/vars/openqa.yml
+++ b/ansible/playbooks/vars/openqa.yml
@@ -16,7 +16,7 @@ rocky_version: 8.5
 rocky_arch: x86_64
 
 # Public download URL for RockyLinux ISOs
-rocky_iso_download_url: "https://download.rockylinux.org/pub/rocky/8.5/isos/{{ rocky_arch }}"
+rocky_iso_download_url: "https://download.rockylinux.org/pub/rocky/{{ rocky_version }}/isos/{{ rocky_arch }}"
 
 # Rocky Linux ISOs
 openqa_isos:
@@ -46,6 +46,9 @@ openqa_worker_count: 1
 # number of workers you want to enable on your system.
 openqa_min_vnc_port: 5991
 openqa_max_vnc_port: "{{ 5990 + openqa_worker_count|int }}"
+
+# The name of the bridge interface to use for multivm networking
+openqa_multivm_bridge_interface: br0
 
 # Packages to install
 openqa_packages:


### PR DESCRIPTION
This PR adds Ansible automation for configuring bridged networking for openQA client-server tests, where SUTs may be required to communicate with each other.